### PR TITLE
tree-sitter-v: lock/rlock expressions and statements

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -591,7 +591,7 @@ module.exports = grammar({
     unsafe_expression: $ => seq('unsafe', $.block),
 
     goto_statement: $ => seq('goto', alias($.identifier, $.label_name)),
-
+    
     labeled_statement: $ => seq(
       field('label', alias($.identifier, $.label_name)),
       ':',
@@ -736,10 +736,17 @@ module.exports = grammar({
       $.comptime_if_expression,
       $.pseudo_comptime_identifier,
       $.sql_expression,
-      $.select_expression
+      $.select_expression,
+      $.lock_expression
     ),
 
     range: $ => prec.right(24, seq(field('start', optional($._expression)), '..', field('end', optional($._expression)))),
+
+    lock_expression: $ => seq(
+      choice('lock', 'rlock'),
+      field('locked_variables', $.expression_list),
+      field('body', $.block)
+    ),
 
     parenthesized_expression: $ => seq(
       '(',

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3114,6 +3114,10 @@
         {
           "type": "SYMBOL",
           "name": "select_expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "lock_expression"
         }
       ]
     },
@@ -3161,6 +3165,40 @@
           }
         ]
       }
+    },
+    "lock_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "lock"
+            },
+            {
+              "type": "STRING",
+              "value": "rlock"
+            }
+          ]
+        },
+        {
+          "type": "FIELD",
+          "name": "locked_variables",
+          "content": {
+            "type": "SYMBOL",
+            "name": "expression_list"
+          }
+        },
+        {
+          "type": "FIELD",
+          "name": "body",
+          "content": {
+            "type": "SYMBOL",
+            "name": "block"
+          }
+        }
+      ]
     },
     "parenthesized_expression": {
       "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -68,6 +68,10 @@
         "named": true
       },
       {
+        "type": "lock_expression",
+        "named": true
+      },
+      {
         "type": "match_expression",
         "named": true
       },
@@ -2023,6 +2027,32 @@
     }
   },
   {
+    "type": "lock_expression",
+    "named": true,
+    "fields": {
+      "body": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "block",
+            "named": true
+          }
+        ]
+      },
+      "locked_variables": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression_list",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "map_type",
     "named": true,
     "fields": {
@@ -3270,6 +3300,10 @@
     "named": true
   },
   {
+    "type": "lock",
+    "named": false
+  },
+  {
     "type": "map",
     "named": false
   },
@@ -3311,6 +3345,10 @@
   },
   {
     "type": "return",
+    "named": false
+  },
+  {
+    "type": "rlock",
     "named": false
   },
   {

--- a/test/corpus/lock.txt
+++ b/test/corpus/lock.txt
@@ -51,4 +51,15 @@ x := rlock a, b { a + b }
 ---
 
 (source_file
-  assignment_staement)
+  (short_var_declaration
+    (expression_list
+      (identifier))
+    (expression_list
+      (lock_expression
+        (expression_list
+	  (identifier)
+	  (identifier))
+	(block
+	  (binary_expression
+	    (identifier)
+	    (identifier)))))))

--- a/test/corpus/lock.txt
+++ b/test/corpus/lock.txt
@@ -1,0 +1,54 @@
+===
+Lock Statement
+===
+
+lock a, b {
+	a++
+	b--
+}
+
+---
+
+(source_file
+  (lock_expression
+    (expression_list
+      (identifier)
+      (identifier))
+    (block
+      (inc_statement
+        (identifier))
+      (dec_statement
+        (identifier)))))
+
+===
+Read Lock Statement
+===
+
+rlock a, b {
+	a++
+	b--
+}
+
+---
+
+(source_file
+  (lock_expression
+    (expression_list
+      (identifier)
+      (identifier))
+    (block
+      (inc_statement
+        (identifier))
+      (dec_statement
+        (identifier)))))
+
+===
+Lock Expression
+===
+
+x := rlock a, b { a + b }
+
+---
+
+(source_file
+  assignment_staement)


### PR DESCRIPTION
This PR adds support for `rlock` and `lock` expressions and statements.