### PR TITLE
tree-sitter-v: add missing bitwise not operator support (~)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -882,7 +882,7 @@ module.exports = grammar({
     ),
 
     unary_expression: $ => prec(PREC.unary, seq(
-      field('operator', choice('+', '-', '!', '^', '*', '&', '<-')),
+      field('operator', choice('+', '-', '!', '~', '^', '*', '&', '<-')),
       field('operand', $._expression)
     )),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3959,6 +3959,10 @@
                 },
                 {
                   "type": "STRING",
+                  "value": "~"
+                },
+                {
+                  "type": "STRING",
                   "value": "^"
                 },
                 {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2870,6 +2870,10 @@
           {
             "type": "^",
             "named": false
+          },
+          {
+            "type": "~",
+            "named": false
           }
         ]
       }
@@ -3363,6 +3367,10 @@
   },
   {
     "type": "}",
+    "named": false
+  },
+  {
+    "type": "~",
     "named": false
   }
 ]

--- a/test/corpus/bit_not.txt
+++ b/test/corpus/bit_not.txt
@@ -1,0 +1,15 @@
+===
+Bitwise Not
+===
+
+assert ~4 == -5
+
+---
+
+(source_file
+  (assert_statement
+    (binary_expression
+      (unary_expression
+        (int_literal))
+      (unary_expression
+        (int_literal)))))


### PR DESCRIPTION
`~` support was missing.