### PR TITLE
Add support for format specifiers in string interpolation

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1047,8 +1047,33 @@ module.exports = grammar({
 
     interpreted_string_literal: $ => stringQuotes($, $.string_interpolation),
 
+    format_flag: $ => token(/[gGeEfFcdoxXpsSc]/),
+
+    format_specifier: $ =>seq(
+      token(':'),
+      choice(
+        $.format_flag,
+        seq(
+          optional(token(/[+-0]/)),
+          $.int_literal,
+          optional(
+            seq(
+              token('.'),
+              $.int_literal,
+            )
+          ),
+          optional($.format_flag)
+        )
+      )
+    ),
+
     string_interpolation: $ => choice(
-      seq('${', $._expression,'}'),
+      seq(
+        '${',
+        $._expression,
+        optional($.format_specifier),
+        '}'
+      ),
       seq('$', $._expression),
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5314,6 +5314,94 @@
         }
       ]
     },
+    "format_flag": {
+      "type": "TOKEN",
+      "content": {
+        "type": "PATTERN",
+        "value": "[gGeEfFcdoxXpsSc]"
+      }
+    },
+    "format_specifier": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": ":"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "format_flag"
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "TOKEN",
+                      "content": {
+                        "type": "PATTERN",
+                        "value": "[+-0]"
+                      }
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "int_literal"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "TOKEN",
+                          "content": {
+                            "type": "STRING",
+                            "value": "."
+                          }
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "int_literal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "format_flag"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
     "string_interpolation": {
       "type": "CHOICE",
       "members": [
@@ -5327,6 +5415,18 @@
             {
               "type": "SYMBOL",
               "name": "_expression"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "format_specifier"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
             },
             {
               "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1511,6 +1511,25 @@
     }
   },
   {
+    "type": "format_specifier",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "format_flag",
+          "named": true
+        },
+        {
+          "type": "int_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "function_declaration",
     "named": true,
     "fields": {
@@ -2882,11 +2901,15 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
         {
           "type": "_expression",
+          "named": true
+        },
+        {
+          "type": "format_specifier",
           "named": true
         }
       ]
@@ -3552,6 +3575,10 @@
   {
     "type": "for",
     "named": false
+  },
+  {
+    "type": "format_flag",
+    "named": true
   },
   {
     "type": "go",

--- a/test/corpus/string_interpolation_format_specifier.txt
+++ b/test/corpus/string_interpolation_format_specifier.txt
@@ -1,0 +1,37 @@
+===
+String Interpolation with Format Specifiers
+===
+
+'${10:10o}'
+'${a:-10}'
+'${b:10.3f}'
+'${c:010.4g}'
+
+---
+
+(source_file
+(interpreted_string_literal
+  (string_interpolation
+    (int_literal)
+    (format_specifier
+      (int_literal)
+      (format_flag))))
+(interpreted_string_literal
+  (string_interpolation
+    (identifier)
+    (format_specifier
+      (int_literal))))
+(interpreted_string_literal
+  (string_interpolation
+    (identifier)
+    (format_specifier
+      (int_literal)
+      (int_literal)
+      (format_flag))))
+(interpreted_string_literal
+  (string_interpolation
+    (identifier)
+    (format_specifier
+      (int_literal)
+      (int_literal)
+      (format_flag)))))

--- a/yarn.lock
+++ b/yarn.lock
@@ -328,7 +328,16 @@
     "string_decoder" "~1.1.1"
     "util-deprecate" "~1.0.1"
 
-"readable-stream@^3.1.1", "readable-stream@^3.4.0":
+"readable-stream@^3.1.1":
+  "integrity" "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA=="
+  "resolved" "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz"
+  "version" "3.6.0"
+  dependencies:
+    "inherits" "^2.0.3"
+    "string_decoder" "^1.1.1"
+    "util-deprecate" "^1.0.1"
+
+"readable-stream@^3.4.0":
   "integrity" "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA=="
   "resolved" "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz"
   "version" "3.6.0"


### PR DESCRIPTION
- Adds syntax rules for using format specifiers in string interpolation
- Adds unit tests
- Adds the updated parser code auto-generated by tree-sitter