### PR TITLE
tree-sitter-v: implement map literal

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -218,6 +218,7 @@ module.exports = grammar({
         $.identifier,
         $._single_line_expression,
         $.type_initializer,
+        $.map,
         $.array,
         $.fixed_array,
         $.unary_expression,
@@ -449,6 +450,16 @@ module.exports = grammar({
         field("name", choice($._field_identifier, $._string_literal, $.int_literal)),
         token.immediate(":"),
         field("value", $._expression)
+      ),
+
+    map: ($) => 
+      prec(
+        PREC.composite_literal,
+        seq(
+          "{", 
+          field("entries", repeat1(seq($.keyed_element, optional(choice(",", terminator))))), 
+          "}"
+        )
       ),
 
     array: ($) => 

--- a/grammar.js
+++ b/grammar.js
@@ -992,7 +992,7 @@ module.exports = grammar({
       ),
 
     cstyle_for_clause: ($) =>
-      prec.right(
+      prec.left(
         seq(
           field("initializer", optional($._simple_statement)),
           ";",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -114,6 +114,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "map"
+        },
+        {
+          "type": "SYMBOL",
           "name": "array"
         },
         {
@@ -1225,6 +1229,73 @@
           }
         }
       ]
+    },
+    "map": {
+      "type": "PREC",
+      "value": -1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "{"
+          },
+          {
+            "type": "FIELD",
+            "name": "entries",
+            "content": {
+              "type": "REPEAT1",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "keyed_element"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": "\n"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "\r"
+                              },
+                              {
+                                "type": "STRING",
+                                "value": "\r\n"
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "}"
+          }
+        ]
+      }
     },
     "array": {
       "type": "PREC_RIGHT",
@@ -5468,7 +5539,7 @@
       }
     },
     "cstyle_for_clause": {
-      "type": "PREC_RIGHT",
+      "type": "PREC_LEFT",
       "value": 0,
       "content": {
         "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -72,6 +72,10 @@
         "named": true
       },
       {
+        "type": "map",
+        "named": true
+      },
+      {
         "type": "none",
         "named": true
       },
@@ -2156,6 +2160,38 @@
         "types": [
           {
             "type": "expression_list",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "type": "map",
+    "named": true,
+    "fields": {
+      "entries": {
+        "multiple": true,
+        "required": true,
+        "types": [
+          {
+            "type": "\n",
+            "named": false
+          },
+          {
+            "type": "\r",
+            "named": false
+          },
+          {
+            "type": "\r\n",
+            "named": false
+          },
+          {
+            "type": ",",
+            "named": false
+          },
+          {
+            "type": "keyed_element",
             "named": true
           }
         ]

--- a/test/corpus/for_statement_cstyle.txt
+++ b/test/corpus/for_statement_cstyle.txt
@@ -26,3 +26,23 @@ fn main() {
           (call_expression 
             (identifier)
             (argument_list (identifier))))))))
+
+===
+C-Style For Statement without Update Statement
+===
+
+for i := 0; i < start_column; {
+	if test {} else {}
+}
+
+---
+
+(source_file
+  (for_statement
+    (cstyle_for_clause
+      (short_var_declaration
+        (identifier_list (identifier))
+        (expression_list (int_literal)))
+      (binary_expression (identifier) (identifier)))
+    (block
+      (if_expression (identifier) (block) (block)))))

--- a/test/corpus/map.txt
+++ b/test/corpus/map.txt
@@ -1,0 +1,20 @@
+===
+Map Literal
+===
+
+{
+  'hello': 'world!',
+  1: 'one',
+  foo: bar
+}
+
+---
+
+(source_file
+  (map
+    (keyed_element
+      (interpreted_string_literal) 
+      (interpreted_string_literal))
+    (keyed_element
+      (int_literal) (interpreted_string_literal))
+    (keyed_element (field_identifier) (identifier))))


### PR DESCRIPTION
In preparation for https://github.com/vlang/v/pull/11035, this implements the untyped-`map` syntax.